### PR TITLE
Fixed bug where adaptors reversed the order of instances when being typed.

### DIFF
--- a/TypeCheck.hs
+++ b/TypeCheck.hs
@@ -508,13 +508,13 @@ applyAdaptor adp ab@(Ab v p@(ItfMap m a') a) =
   case adpToCompilableAdp ab adp of
     Nothing -> Nothing
     Just adp'@(CompilableAdp x m' ns a'') ->
-      let instances = (reverse . bwd2fwd) (M.findWithDefault BEmp x m) in
-      let instances' = map (instances !!) ns in
+      let instances = bwd2fwd (M.findWithDefault BEmp x m) in
+      let instances' = map (reverse instances !!) ns in
       if null instances' then
         Just (adp', Ab v (ItfMap (M.delete x m) a') a)
       else
         Just (adp', Ab v (ItfMap (
-          M.insert x ((fwd2bwd . reverse) instances') m
+          M.insert x (fwd2bwd instances') m
         ) a') a)
 
 adpToCompilableAdp :: Ab Desugared -> Adaptor Desugared -> Maybe (Adaptor Desugared)

--- a/TypeCheck.hs
+++ b/TypeCheck.hs
@@ -509,6 +509,8 @@ applyAdaptor adp ab@(Ab v p@(ItfMap m a') a) =
     Nothing -> Nothing
     Just adp'@(CompilableAdp x m' ns a'') ->
       let instances = bwd2fwd (M.findWithDefault BEmp x m) in
+      -- The indices in ns index from the end of instances, thus we reverse
+      -- instances before indexing into it
       let instances' = map (reverse instances !!) ns in
       if null instances' then
         Just (adp', Ab v (ItfMap (M.delete x m) a') a)

--- a/tests/should-fail/adaptors/r.multiple-order.fk
+++ b/tests/should-fail/adaptors/r.multiple-order.fk
@@ -1,0 +1,22 @@
+-- #desc Regression test for a special case involving multiple instances of the same interface
+-- #return cannot unify abilities [£ | Eff ( A ) , Eff ( B ) , Eff ( B )] (line 13 , column 24) and [£ | Eff ( B ) , Eff ( B ) , Eff ( A )] (line 13 , column 24)
+
+interface Eff X = oper : X
+
+data A = a
+data B = b
+
+handleA : <Eff A> X -> X
+handleA x = x
+handleA <oper -> k> = handleA (k a)
+
+single : <Eff B> X -> [Eff A, Eff B] X
+single x = x
+single <oper -> k> = <Eff(s a b -> s b b a)> (k b)
+
+full : <Eff B> X -> [Eff A] X
+full x = x
+full <m> = full (single (<Eff(s a b b -> s b a)> m!))
+
+main : {B}
+main! = handleA (full oper!)

--- a/tests/should-pass/adaptors/r.multiple-order.fk
+++ b/tests/should-pass/adaptors/r.multiple-order.fk
@@ -1,0 +1,22 @@
+-- #desc Regression test for a special case involving multiple instances of the same interface
+-- #return b
+
+interface Eff X = oper : X
+
+data A = a
+data B = b
+
+handleA : <Eff A> X -> X
+handleA x = x
+handleA <oper -> k> = handleA (k a)
+
+single : <Eff B> X -> [Eff A, Eff B] X
+single x = x
+single <oper -> k> = <Eff(s a b -> s a b b)> (k b)
+
+full : <Eff B> X -> [Eff A] X
+full x = x
+full <m> = full (single (<Eff(s a b b -> s a b)> m!))
+
+main : {B}
+main! = handleA (full oper!)


### PR DESCRIPTION
This PR fixes issue #7. Credit to @slindley for the fix. Before the fix, the should-fail example would type check, run, but produce the value `a` of type `A`, thus breaking preservation.

### Explanation of bug and fix

Abilites are snoc lists, and so the rightmost interface instance is the active one. Suppose we have an interface `Eff X` and that the ambient ability, when restricted to `Eff`, is `[Eff A, Eff B]`. The list `ns` in `applyAdaptor` is a list of indices into the restricted ambient ability as a snoc list, i.e. right-to-left so 0 corresponds to `Eff B`. Thus, when indexing into `instances`, we should index from the back. Thus the first change is for clarity. The order of the indices in `ns`, however, is cons list order, i.e. left-to-right. Suppose that `ns` is `[0,0,1]`. Then this represents the adaptor `<Eff(s a b -> s a b b)>`. Therefore, we should not reverse `instances'` as it is already in the correct form of a cons list. Thus the second change is for correctness.